### PR TITLE
v1.0-canary.2 (ISR)

### DIFF
--- a/src/app/[...slug]/components/Block.tsx
+++ b/src/app/[...slug]/components/Block.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import Flexbox from './blocks/Flexbox'
+import Text from './blocks/Text'
+
+type Props = {
+    blocks: BlockData[]
+    block: BlockData
+}
+
+export default function Block({ blocks, block }: Props) {
+    if(block.type === "flexbox")    return <Flexbox blocks={blocks} block={block} />
+    if(block.type === "text")       return <Text blocks={blocks} block={block} />
+}

--- a/src/app/[...slug]/components/Page.tsx
+++ b/src/app/[...slug]/components/Page.tsx
@@ -1,0 +1,15 @@
+type Props = {
+    params: {
+        slug: string[],
+        searchParams: any
+    },
+    page: PageData
+}
+export default function Page({ params, page }: Props) {
+    return (
+        <body>
+            <h1>{page.title}</h1>
+            <p>{page.description}</p>
+        </body>
+    )
+}

--- a/src/app/[...slug]/components/Page.tsx
+++ b/src/app/[...slug]/components/Page.tsx
@@ -1,3 +1,6 @@
+import { getChildren } from "@/app/admin/editor/page/components/blocks"
+import Block from "./Block"
+
 type Props = {
     params: {
         slug: string[],
@@ -5,11 +8,13 @@ type Props = {
     },
     page: PageData
 }
+
 export default function Page({ params, page }: Props) {
     return (
-        <body>
-            <h1>{page.title}</h1>
-            <p>{page.description}</p>
+        <body className="page">
+            {getChildren(page.blocks, "").map((block, i) => (
+                <Block key={block.blockId} blocks={page.blocks} block={block} />
+            ))}
         </body>
     )
 }

--- a/src/app/[...slug]/components/blocks/Flexbox.tsx
+++ b/src/app/[...slug]/components/blocks/Flexbox.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import { getChildren } from '@/app/admin/editor/page/components/blocks'
+import Block from '../Block'
+
+type Props = {
+    blocks: BlockData[]
+    block: BlockData
+}
+export default function Flexbox({ blocks, block }: Props) {
+    return (
+        <div className="flexbox">
+            {getChildren(blocks, block.blockId).map((block, i) => (
+                <Block blocks={blocks} block={block} />
+            ))}
+        </div>
+    )
+}

--- a/src/app/[...slug]/components/blocks/Text.tsx
+++ b/src/app/[...slug]/components/blocks/Text.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import styles from '../../page.module.scss'
+
+type Props = {
+    blocks: BlockData[]
+    block: BlockData
+}
+export default function Text({ blocks, block }: Props) {
+    const type = {type: block.properties.type || "p"};
+
+    return (
+        <type.type>
+            {block.properties.text || "Enter text here..."}
+        </type.type>
+    )
+}

--- a/src/app/[...slug]/fetching.tsx
+++ b/src/app/[...slug]/fetching.tsx
@@ -1,0 +1,37 @@
+import prisma from "../util/prisma";
+
+
+export async function getPageURLs(): Promise<string[]> {
+    
+    try {
+        const urls = await prisma.page.findMany({
+            select: {
+                url: true
+            }
+        });
+
+        return urls.map(page => page.url);
+    } catch (error) {
+        console.error("Could not fetch page urls:", error);
+        return [];
+    }
+}
+
+
+export async function getPage(url: string): Promise<PageData|null> {
+    try {
+        let page = await prisma.page.findUnique({
+            where: {
+                url: url
+            }
+        });
+        if(!page) {
+            return null;
+        }
+        const { id, ...pageData } = page;
+        return pageData as any;
+    } catch (error) {
+        console.log("Could not fetch page:", error);
+        return null;
+    }
+}

--- a/src/app/[...slug]/page.tsx
+++ b/src/app/[...slug]/page.tsx
@@ -1,0 +1,55 @@
+import Page from "./components/Page";
+import { getPage, getPageURLs } from "./fetching";
+
+
+type Props = {
+    params: {
+        slug: string[],
+        searchParams: any
+    }
+}
+
+
+export default async function PageWrapper({ params }: Props) {
+    let page = await getPage(params.slug.join('/'));
+
+    if (!page) {
+        return <div>Could not find page !</div>
+    }
+
+    return (
+        <Page params={params} page={page} />
+    )
+}
+
+
+export async function generateStaticParams() {
+    let paths = await getPageURLs();
+    return paths.map(path => ({
+        params: {
+            slug: path.split('/')
+        }
+    }));
+
+}
+
+
+export async function generateMetadata({ params }: Props) {
+    let page = await getPage(params.slug.join('/'));
+
+    if (!page) {
+        return {
+            notFound: true,
+        }
+    }
+
+    return {
+        title: page.title,
+        description: page.description,
+    }
+}
+
+
+
+export const dynamicParams = true;
+export const revalidate = false;

--- a/src/app/admin/editor/page/components/BlocksEditor.tsx
+++ b/src/app/admin/editor/page/components/BlocksEditor.tsx
@@ -12,7 +12,6 @@ import dynamic from 'next/dynamic';
 
 type Props = {}
 function BlocksEditor({ }: Props) {
-    if (typeof window === "undefined") return <div></div>;
     const { editor, blocks, setBlocks, activeBlock, setActiveBlock } = usePageEditorContext();
 
     const mousePos = useRef({ x: 0, y: 0 });
@@ -108,7 +107,7 @@ function BlocksEditor({ }: Props) {
 
 
 
-
+    if (typeof window === "undefined") return <div></div>;
 
     return (
         <div className={styles.pagePreview} style={{ backgroundColor: 'white', width: `${previewWidth*editor.zoom}px`}}

--- a/src/app/admin/editor/page/components/blocks/Flexbox.tsx
+++ b/src/app/admin/editor/page/components/blocks/Flexbox.tsx
@@ -12,7 +12,7 @@ type Props = {
 function Flexbox({ blocks, block }: Props) {
 
     return (
-        <div className={`${styles.container} ${styles.flexbox}`}>
+        <div className={`${styles.container} ${styles.flexbox} flexbox`}>
             <SortableContext items={getChildrenIds(blocks, block.blockId)} strategy={() => null}>
                 {getChildren(blocks, block.blockId).map((child, index) => (
                     <SortableBlock key={child.blockId} blocks={blocks} block={child} />

--- a/src/app/admin/editor/page/components/blocks/Text.tsx
+++ b/src/app/admin/editor/page/components/blocks/Text.tsx
@@ -55,10 +55,10 @@ function Text({ blocks, block }: Props) {
     }
     
     return (
-        <type.type className={`${styles.text}`}
+        <type.type className={`${styles.text} text`}
             onDoubleClick={() => setEditing(true)}>
             {isEditing ? (
-                <textarea className={`${styles.text}`} value={text} ref={inputRef}
+                <textarea className={`${styles.text} text`} value={text} ref={inputRef}
                     onChange={(e) => { updateText(e.target.value); adjustInputHeight(); } }
                     onBlur={() => setEditing(false)}
                     onKeyDown={(e) => { if(e.key==="Escape") setIsEditing(false); } }/>

--- a/src/app/admin/editor/page/pageEditor.module.scss
+++ b/src/app/admin/editor/page/pageEditor.module.scss
@@ -108,11 +108,17 @@
         color: inherit;
         cursor: pointer;
         fill: white;
+        p {
+            color: white;
+        }
     
         &:hover {
             color: #66acf7;
             fill: #66acf7;
             transform: scale(1.05);
+            p {
+                color: #66acf7;
+            }
         }
 
         svg {
@@ -398,7 +404,6 @@
 
 // !===== Blocks (default styling, overriden by inline-css) =====
 .container {
-    padding: 8px;
     &:empty {
         min-height: 32px;
     }
@@ -419,6 +424,7 @@
 
     .text {
         width: 100%;
+        user-select: none;
 
         &:empty {
             min-height: 32px;
@@ -430,16 +436,8 @@
     }
 }
 
-// Default values for blocks
 .text {
-    padding: 0;
-    margin: 0;
-    border: none; outline: none;
-    font-family: sans-serif;
-    font-size: 16px;
-    font-weight: 400;
     resize: none;
     overflow: visible;
-    white-space: pre-line;
-    user-select: none;
+    border: none; outline: none;
 }

--- a/src/app/api/page/route.ts
+++ b/src/app/api/page/route.ts
@@ -27,7 +27,7 @@ export async function GET(req: NextRequest) {
 export async function POST(req: NextRequest) {
     if (!req.body) return new Response(JSON.stringify({ message: "Missing body !" }), { status: 400 });
     const page: PageData = await req.json();
-    page.updatedAt = new Date().toISOString();
+    page.updatedAt = new Date();
 
     if (!page.url || !page.title || !page.blocks) 
         return new Response(JSON.stringify({ message: "Missing parameters (url, title or blocks) !" }), { status: 400 });
@@ -49,7 +49,7 @@ export async function POST(req: NextRequest) {
 export async function PUT(req: NextRequest) {
     if (!req.body) return new Response(JSON.stringify({ message: "Missing body !" }), { status: 400 });
     const page: PageData = await req.json();
-    page.updatedAt = new Date().toISOString();
+    page.updatedAt = new Date();
 
     if (!page.url || !page.title || !page.blocks) 
         return new Response(JSON.stringify({ message: "Missing parameters (url, title or blocks) !" }), { status: 400 });

--- a/src/app/api/page/route.ts
+++ b/src/app/api/page/route.ts
@@ -1,4 +1,6 @@
+import { revalidate } from "@/app/page";
 import prisma from "@/app/util/prisma";
+import { revalidatePath } from "next/cache";
 import { NextRequest } from "next/server";
 
 export async function GET(req: NextRequest) {
@@ -40,6 +42,7 @@ export async function POST(req: NextRequest) {
         return new Response(JSON.stringify({ message: "Could not create page !\n"+error }), { status: 500 });
     }
     
+    revalidatePath("/"+page.url);
 
     return new Response(JSON.stringify({ message: "Page successfully created !" }), { status: 201 });
 }
@@ -65,6 +68,8 @@ export async function PUT(req: NextRequest) {
         return new Response(JSON.stringify({ message: "Could not update page !\n"+error }), { status: 500 });
     }
 
+    revalidatePath("/"+page.url);
+
     return new Response(JSON.stringify({ message: "Page successfully updated !" }), { status: 200 });
 }
 
@@ -85,6 +90,8 @@ export async function DELETE(req: NextRequest) {
     } catch (error) {
         return new Response(JSON.stringify({ message: "Could not delete page !\n"+error }), { status: 500 });
     }
+
+    revalidatePath("/"+url);
 
     return new Response(JSON.stringify({ message: "Page successfully deleted !" }), { status: 200 });
 }

--- a/src/app/api/page/route.ts
+++ b/src/app/api/page/route.ts
@@ -3,7 +3,7 @@ import { NextRequest } from "next/server";
 
 export async function GET(req: NextRequest) {
     const url = req.nextUrl.searchParams.get("url");
-    if (!url)
+    if (url === null || url === undefined)
         return new Response(JSON.stringify({ message: "Missing parameters (url) !" }), { status: 400 });
 
     try {
@@ -29,7 +29,7 @@ export async function POST(req: NextRequest) {
     const page: PageData = await req.json();
     page.updatedAt = new Date();
 
-    if (!page.url || !page.title || !page.blocks) 
+    if ((page.url === null || page.url === undefined) || (page.title === null || page.title === undefined) || !page.blocks)
         return new Response(JSON.stringify({ message: "Missing parameters (url, title or blocks) !" }), { status: 400 });
 
     try {        
@@ -51,7 +51,7 @@ export async function PUT(req: NextRequest) {
     const page: PageData = await req.json();
     page.updatedAt = new Date();
 
-    if (!page.url || !page.title || !page.blocks) 
+    if ((page.url === null || page.url === undefined) || (page.title === null || page.title === undefined) || !page.blocks)
         return new Response(JSON.stringify({ message: "Missing parameters (url, title or blocks) !" }), { status: 400 });
 
     try {
@@ -73,7 +73,7 @@ export async function PUT(req: NextRequest) {
 export async function DELETE(req: NextRequest) {
     const url = req.nextUrl.searchParams.get("url");
 
-    if (!url)
+    if (url === null || url === undefined)
         return new Response(JSON.stringify({ message: "Missing parameters (url) !" }), { status: 400 });
 
     try {

--- a/src/app/api/revalidate/route.ts
+++ b/src/app/api/revalidate/route.ts
@@ -1,0 +1,12 @@
+import { revalidatePath } from "next/cache";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function POST(req: NextRequest) {
+    //TODO: add authentication so that only the owner of the site can revalidate (from the editor)
+
+    const url = req.nextUrl.searchParams.get("url");
+    if (!url) return NextResponse.json({ message: "No url provided" }, { status: 400 });
+
+    revalidatePath(url);
+    return NextResponse.json({ revalidated: true, now: Date.now()}, { status: 200 });
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,26 +1,62 @@
-:root {
-  
-}
+:root {}
 
 @media (prefers-color-scheme: dark) {
-  :root {
-    
-  }
+    :root {}
 }
 
 * {
-  box-sizing: border-box;
-  padding: 0;
-  margin: 0;
+    box-sizing: border-box;
+    padding: 0;
+    margin: 0;
 }
 
 html,
 body {
-  max-width: 100vw;
-  overflow-x: hidden;
+    max-width: 100vw;
+    overflow-x: hidden;
 }
 
 a {
-  color: inherit;
-  text-decoration: none;
+    color: inherit;
+    text-decoration: none;
+}
+
+
+/*!===== DEFAULT VALUES =====!*/
+p, .text {
+    font-family: sans-serif;
+    font-size: 1rem;
+    font-weight: 400;
+    line-height: 1.5;
+    white-space: pre-line;
+    color: black;
+}
+
+h1 {}
+
+h2 {}
+
+h3 {}
+
+h4 {}
+
+h5 {}
+
+h6 {}
+
+.flexbox {
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-start;
+    align-items: flex-start;
+
+    padding: 8px 16px;
+}
+
+.page {
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    align-items: flex-start;
+    gap: 0;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,42 @@
-import styles from './page.module.css'
+import Page from './[...slug]/components/Page'
+import { getPage } from './[...slug]/fetching'
 
-export default function Home() {
-  return (
-    <main>
-      Homepage
-    </main>
-  )
+type Props = {
+    params: {
+        slug: string[]
+        searchParams: any
+    }
 }
+
+export default async function PageWrapper({ params }: Props) {
+    let page = await getPage("");
+    params.slug = [""]
+
+    if (!page) {
+        return (
+            <body>
+                <div>Could not find page !</div>
+            </body>
+        )
+    }
+
+    return <Page params={params} page={page} />
+}
+
+export async function generateMetadata({ params }: Props) {
+    let page = await getPage("")
+
+    if (!page) {
+        return {
+            notFound: true
+        }
+    }
+
+    return {
+        title: page.title,
+        description: page.description
+    }
+}
+
+export const dynamicParams = true
+export const revalidate = false

--- a/types.d.ts
+++ b/types.d.ts
@@ -18,8 +18,8 @@ type PageData = {
     keywords: string[],
     author: string,
     iconURL: string,
-    createdAt: string,
-    updatedAt: string,
+    createdAt: Date,
+    updatedAt: Date,
     properties: {
         [key: string]: any
     }


### PR DESCRIPTION
Added on-demand ISR. Pages use SSR and the data in the database. Once rendered they are cached and only re-rendered when revalidatePath is called (route or when saving a page in the editor).

- Create the dynamic path page [...slug] and the homepage
- Load page from the database (server-side)
- Revalidation route to force a page to re-render on next request
- Auto-revalidation when saving a page in the editor
- Page block rendering: flexbox and text
- Common default block styling in the editor and the actual pages